### PR TITLE
Suppressdialogs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -194,6 +194,17 @@ namespace MXSPyCOM
 		}
 
 
+		static string mxs_filein_catch_errors_cmd(string filepath)
+		{
+			string file_line = String.Format(" Error while running: {0}", filepath);
+			string mxs_exception_array = "(filterString (getCurrentException()) \"\n\")";
+			string trycmd = String.Format("filein(@\"{0}\")", filepath);
+			string catchcmd = String.Format("(for i in #(\"{0}\") + {1} do print i)", file_line, mxs_exception_array);
+			string trycatchcmd = String.Format("try({0}) catch({1})", trycmd, catchcmd);
+			return trycatchcmd;
+		}
+
+
 		static void show_message(string message, bool info = false)
 		{
 			/// Displays an error or informational dialog if the execution of MXSPyCOM encounters a problem. 

--- a/Program.cs
+++ b/Program.cs
@@ -229,15 +229,15 @@ namespace MXSPyCOM
 			string ext = System.IO.Path.GetExtension(filepath).ToLower();
 
 			string location;
-			string runcall;
+			string run_cmd;
 
 			if (ext == ".py")
 			{
 				/// For python files, use passed filepath for location msg, no pos or line available
-				location = String.Format("\"\nError; filename: {0}\"", filepath);
+				location = String.Format("\" Error; filename: {0}\"", filepath);
 
 				/// Pass thru python.ExecuteFile()
-				runcall = String.Format("python.ExecuteFile(@\"{0}\")", filepath);
+				run_cmd = String.Format("python.ExecuteFile(@\"{0}\")", filepath);
 			}
 			else
 			{
@@ -245,14 +245,15 @@ namespace MXSPyCOM
 				string loc_file = "\" filename: \" + (getErrorSourceFileName() as string)";
 				string loc_pos = "\"; position: \" + ((getErrorSourceFileOffset() as integer) as string)";
 				string loc_line = "\"; line: \" + ((getErrorSourceFileLine() as integer) as string)";
-				location = String.Format("\"\nError;\" + {0} + {1} + {2}", loc_file, loc_pos, loc_line);
+				location = String.Format("\" Error;\" + {0} + {1} + {2}", loc_file, loc_pos, loc_line);
 
 				/// Pass thru filein()
-				runcall = String.Format("filein(@\"{0}\")", filepath);
+				run_cmd = String.Format("filein(@\"{0}\")", filepath);
 			}
 			string exception_array = "(filterString (getCurrentException()) \"\n\")";
-			string print_error = String.Format("(for i in #({0}) + {1} do print i)", location, exception_array);
-			string cmd = String.Format("try({0}) catch({1})", runcall, print_error);
+
+			string exception_msg = String.Format("(for i in #({0}) + {1} do setListenerSelText (\"\n\" + i))", location, exception_array);
+			string cmd = String.Format("try({0}) catch({1})", run_cmd, exception_msg);
 			return cmd;
 		}
 


### PR DESCRIPTION
Relevant history and description here : https://github.com/JeffHanna/MXSPyCOM/issues/2

The current implementation here is working reliably. It takes the maxscript command string and wraps it in more maxscript code before giving it to 3ds max for execution. That extra code consists of a try() catch() to subvert error dialogs if the command raises an exception when called in 3ds Max, and some language-dependent code for generating a homemade exception message to be output in the Max listener window. 

A solution which finds and closes the error dialog popups would give a native exception output. I haven't attempted that, mostly because wrapping it all in a try() catch() is just more contained, avoids interference with GUI elements. 

I'm happy to make any requested adjustments in the implementation. I'll include some detail here about the current output messages.

## How the output messages are generated

If running a Python file, a decent error message is made from only the array given by the maxscript command `getCurrentException()`. 

If running a Maxscript file, the filename, position, and line number are retrieved with maxscript commands `getErrorSourceFileName()`, `getErrorSourceFileOffset()`, `getErrorSourceFileLine()`, and `getCurrentException()` respectively.

I've just formatted these commands in a reasonably conformed way, leaning towards keeping things simple. 

## Improvements to the output messages

### Double Quotes

Currently, each line has to be printed with double quotes. I think using `setListenerSelText` from [ this doc page](https://help.autodesk.com/view/3DSMAX/2018/ENU/?guid=__files_GUID_1FAB9988_C24A_44DF_87F8_0739D50CF444_htm) to print the output may rectify this. I will try this within the next week, possibly the next few days.

The current implementation includes an extra `\n` on the first line. That is a personalization that I'll remove.

### Content
The current messages differ quite a bit from the one generated by Max, but I don't know if there's a standard to the anatomy of exception messages. In this case, I find it handy to have the start of the trace readout on the last line, so that it's displayed in the mini-listener in Max. The tracebacks from `getCurrentException()` lack detail in most cases, but not all. I went through the commands in the [MAXScript Try Expression Documentation](https://help.autodesk.com/view/3DSMAX/2018/ENU/?guid=__files_GUID_36BA05E8_2F9A_4761_8D9B_40E3BC6503BF_htm) and wasn't able to get anything from `getCurrentExceptionCallStack` in 3ds Max 2018. 

### Color
The Max exceptions print in red. I'm pretty sure there's no way to get anything except blue with user-generated output.